### PR TITLE
fix 🐛(dns): ignore https-redirect httproute to avoid wildcard record …

### DIFF
--- a/gitops/apps/istio-gateway-api/public-gateway.yaml
+++ b/gitops/apps/istio-gateway-api/public-gateway.yaml
@@ -49,13 +49,15 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: https-redirect
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: ignore
 spec:
   parentRefs:
-  - name: public
-    sectionName: http
+    - name: public
+      sectionName: http
   rules:
-  - filters:
-    - type: RequestRedirect
-      requestRedirect:
-        scheme: https
-        statusCode: 301
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301


### PR DESCRIPTION
…on Cloudflare