### PR TITLE
fix 🐛 (minio): increase HTTP route timeouts from 0s to 3600s

### DIFF
--- a/gitops/apps/minio/generic/httproute.yaml
+++ b/gitops/apps/minio/generic/httproute.yaml
@@ -30,8 +30,9 @@ spec:
         - name: minio-generic
           port: 9000
       timeouts:
-        backendRequest: 30m
-        request: "0s"
+      timeouts:
+        request: "3600s"
+        backendRequest: "3600s"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
